### PR TITLE
Add 3001 as default port for backend

### DIFF
--- a/backend/utils/config.js
+++ b/backend/utils/config.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 
-const { MONGODB_URI, PORT } = process.env;
+const { MONGODB_URI } = process.env;
+const PORT = process.env.PORT || 3001;
 
 module.exports = {
   MONGODB_URI,


### PR DESCRIPTION
If no port is provided in the .env, the backend will use 3001 instead.